### PR TITLE
Final update for 1.93

### DIFF
--- a/VMware_Inventory_ReadMe_1_9.rtf
+++ b/VMware_Inventory_ReadMe_1_9.rtf
@@ -1,6 +1,6 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch0\stshfloch31506\stshfhich31506\stshfbi31506\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f38\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0302020204030204}Calibri Light;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f38\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0302020204030204}Calibri Light;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fhimajor\f31502\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0302020204030204}Calibri Light;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
@@ -109,15 +109,15 @@
 \listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls6}{\listoverride\listid319386001
 \listoverridecount0\ls7}{\listoverride\listid967903918\listoverridecount0\ls8}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}{\pgp\ipgp0\itap0\li0\ri0\sb0
 \sa0}}{\*\rsidtbl \rsid525249\rsid797280\rsid939389\rsid2100909\rsid3086507\rsid3099961\rsid5046830\rsid5402716\rsid5724710\rsid5901322\rsid6435714\rsid6567510\rsid6889259\rsid7548235\rsid7552153\rsid7935776\rsid8083966\rsid8258882\rsid8286907\rsid9069446
-\rsid9462546\rsid9517336\rsid9527330\rsid9901034\rsid10501565\rsid12405189\rsid13192252\rsid13248093\rsid13375129\rsid13524541\rsid13845677\rsid14043424\rsid14749003\rsid15142793\rsid15276959\rsid15868338\rsid16283016\rsid16392362}{\mmathPr\mmathFont34
-\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author Jake Rutski}{\operator Webster}{\creatim\yr2016\mo10\dy3\hr9\min42}{\revtim\yr2021\mo9\dy21\hr5\min36}{\version25}{\edmins117}
-{\nofpages18}{\nofwords5088}{\nofchars29005}{\nofcharsws34025}{\vern31}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid9462546\rsid9517336\rsid9527330\rsid9901034\rsid10501565\rsid12405189\rsid13192252\rsid13248093\rsid13375129\rsid13524541\rsid13845677\rsid14043424\rsid14749003\rsid15142793\rsid15276959\rsid15868338\rsid16072335\rsid16283016\rsid16392362}{\mmathPr
+\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author Jake Rutski}{\operator Carl Webster}{\creatim\yr2016\mo10\dy3\hr9\min42}{\revtim\yr2022\mo2\dy23\hr8\min40}{\version26}
+{\edmins122}{\nofpages18}{\nofwords5206}{\nofchars29675}{\nofcharsws34812}{\vern41}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont1\relyonvml0\donotembedlingdata0\grfdocevents0\validatexml1\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors1\noxlattoyen
 \expshrtn\noultrlspc\dntblnsbdb\nospaceforul\formshade\horzdoc\dgmargin\dghspace180\dgvspace180\dghorigin1440\dgvorigin1440\dghshow1\dgvshow1
 \jexpand\viewkind1\viewscale111\pgbrdrhead\pgbrdrfoot\splytwnine\ftnlytwnine\htmautsp\nolnhtadjtbl\useltbaln\alntblind\lytcalctblwd\lyttblrtgr\lnbrkrule\nobrkwrptbl\snaptogridincell\allowfieldendsel\wrppunct
 \asianbrkrule\rsidroot9069446\newtblstyruls\nogrowautofit\usenormstyforlist\noindnmbrts\felnbrelev\nocxsptable\indrlsweleven\noafcnsttbl\afelev\utinl\hwelev\spltpgpar\notcvasp\notbrkcnstfrctbl\notvatxbx\krnprsnet\cachedcolbal \nouicompat \fet0
 {\*\wgrffmtfilter 2450}\nofeaturethrottle1\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MzCxNDKyNDU3MjY0NDJU0lEKTi0uzszPAykwNKwFAPsX0I8tAAAA}}\ltrpar \sectd \ltrsect\linex0\endnhere\sectlinegrid360\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang 
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MzCxNDKyNDU3MjY0NDJU0lEKTi0uzszPAykwNKoFADhE/aQtAAAA}}\ltrpar \sectd \ltrsect\linex0\endnhere\sectlinegrid360\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang 
 {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}
 {\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9
 \pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid9069446 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -255,7 +255,7 @@ Credentials to your VCenter server \hich\f31506 \endash \loch\f31506  if the scr
 \hich\af37\dbch\af31505\loch\f37 To use the Chart option, install the }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15142793 \hich\af37\dbch\af31505\loch\f37  HYP\hich\af37\dbch\af31505\loch\f37 
 ERLINK "https://www.microsoft.com/en-us/download/details.aspx?id=14422" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15142793 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b96000000680074007400700073003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f00
-640065007400610069006c0073002e0061007300700078003f00690064003d00310034003400320032000000795881f43b1d7f48af2c825dc485276300000000a5ab000351ff7f0000001000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+640065007400610069006c0073002e0061007300700078003f00690064003d00310034003400320032000000795881f43b1d7f48af2c825dc485276300000000a5ab000351ff7f000000100000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid15142793\charrsid15142793 \hich\af37\dbch\af31505\loch\f37 Microsoft Chart Controls for Microsoft .NET Fra\hich\af37\dbch\af31505\loch\f37 mework 3.5}}}\sectd \ltrsect\linex0\endnhere\sectlinegrid360\sectdefaultcl\sftnbj {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid15142793 .
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid525249 \rtlch\fcs1 \af0\afs26\alang1025 \ltrch\fcs0 
@@ -332,68 +332,69 @@ Import parameter \hich\f37 \endash \loch\f37  this does not require }{\rtlch\fcs
 \fs26\cf19\lang1033\langfe1033\loch\af31502\hich\af31502\dbch\af31501\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\cf23\dbch\af31505\insrsid9901034 \hich\af31502\dbch\af31505\loch\f31502 Help Text
 \par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9527330 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9527330 
-\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7552153 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \\\hich\af2\dbch\af31505\loch\f2 
+\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16072335 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 NAME
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \\\hich\af2\dbch\af31505\loch\f2 
 VMware_Inventory_1_9.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a VMware vSphere datacenter using PowerCLI and
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Microsoft Word, PDF, plain text, or HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Microsoft Word, PDF, plain text, or HTML.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \\\hich\af2\dbch\af31505\loch\f2 
-VMware_Inventory_1_9.ps1 [-VIServerName <String>] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Full] [-Export] [-Import] [-Dev] [-Log] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [-ReportFooter] [-Issues] [-PCLICustom] [-MSWord] [-Chart] [-CompanyAddress }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>]}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2     [-Company\hich\af2\dbch\af31505\loch\f2 Phone <String>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \\\hich\af2\dbch\af31505\loch\f2 
+VMware_Inventory_1_9.ps1 [-VIServerName <String>] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Full] [-Export] [\hich\af2\dbch\af31505\loch\f2 -Import] [-Dev] [-Log] [-ScriptInfo] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-ReportFooter] [-Issues] [-PCLICustom] [-MSWord] [-Chart] [-CompanyAddress }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-UserName\hich\af2\dbch\af31505\loch\f2  <String>] [-SmtpServer }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \\\hich\af2\dbch\af31505\loch\f2 
-VMware_Inventory_1_9.ps1 [-VIServerName <String>] [-HTML] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \line \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 
-\hich\af2\dbch\af31505\loch\f2 [\hich\af2\dbch\af31505\loch\f2 -AddDateTime] [-Folder <String>] [-Full] [-Export] [-Import] [-Dev] [-Log] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-ReportFooter] [-Issues] [-PCLICustom] [-SmtpServer <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [-SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To <String>] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \\\hich\af2\dbch\af31505\loch\f2 
+VMware_Inventory_1_9.ps1 [-VIServerName <String>] [-HTML] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-AddDateTime] [-Folder <String>] [-Full] [-Export] [-Import] [-D\hich\af2\dbch\af31505\loch\f2 ev] [-Log] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-ReportFooter] [-Issues] [-PCLICustom] [-SmtpServer <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2 C:\\PSS\hich\af2\dbch\af31505\loch\f2 cript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \\
-\hich\af2\dbch\af31505\loch\f2 VMware_Inventory_1_9.ps1 [-VIServerName <String>] [-Text] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [-AddDateTime] [-Folder <String>] [-Full] [-Export] [-Import] [-Dev] [-Log] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-ReportFooter] [-Issues] [-PCLICustom] [-SmtpServer <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [-SmtpPort <Int32>] [-Us\hich\af2\dbch\af31505\loch\f2 
-eSSL] [-From <String>] [-To <String>] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \\\hich\af2\dbch\af31505\loch\f2 
+VMware_Inventory_1_9.ps1 [-VIServerName <String>] [-Text] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-AddDateTi\hich\af2\dbch\af31505\loch\f2 me] [-Folder <String>] [-Full] [-Export] [-Import] [-Dev] [-Log] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-ReportFooter] [-Issues] [-PCLICustom] [-SmtpServer <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To <String>] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2 C:\\PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \\\hich\af2\dbch\af31505\loch\f2 
-VMware_Inventory_1_9.ps1 [-VIServerName <String>] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Full] [-Export] [-Import] [-Dev] [-Log] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [-ReportFooter] [-Issues] [-PC\hich\af2\dbch\af31505\loch\f2 
-LICustom] [-PDF] [-Chart] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 <String>] [-CoverPage <String>] [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \\\hich\af2\dbch\af31505\loch\f2 
+VMware_Inventor\hich\af2\dbch\af31505\loch\f2 y_1_9.ps1 [-VIServerName <String>] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>] [-Full] [-Export] [-Import] [-Dev] [-Log] [-ScriptInfo] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-ReportFooter] [-Issues] [-PCLICustom] [-PDF] [-Chart] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] \hich\af2\dbch\af31505\loch\f2 [-CompanyName <String>] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [-UserName <String>] [-SmtpServer }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 <String>] [-SmtpPort <Int32>] [-UseSSL] [-From <String>] [-To <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a VMware vSphere datacenter using PowerCLI and
+\par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a VM\hich\af2\dbch\af31505\loch\f2 ware vSphere datacenter using PowerCLI and
 \par \hich\af2\dbch\af31505\loch\f2     Microsoft Word, PDF, plain text, or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a document named after the vCenter server.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The Word/PDF Document includes a Cover Page, Table of Contents, an\hich\af2\dbch\af31505\loch\f2 d Footer.
+\par \hich\af2\dbch\af31505\loch\f2     The Word/PDF Document includes a Cover Page, Table of Contents, and Footer.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
@@ -406,15 +407,15 @@ LICustom] [-PDF] [-Chart] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \l
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
 \par \hich\af2\dbch\af31505\loch\f2         Portuguese
-\par \hich\af2\dbch\af31505\loch\f2         S\hich\af2\dbch\af31505\loch\f2 panish
-\par \hich\af2\dbch\af31505\loch\f2         Swedish
+\par \hich\af2\dbch\af31505\loch\f2         Spanish
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Swedish
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
 \par \hich\af2\dbch\af31505\loch\f2     -VIServerName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Name of the vCenter Server to connect to.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is mandatory and does not have a default value.
-\par \hich\af2\dbch\af31505\loch\f2         FQDN should be used; hostname can be used if it can be resolved \hich\af2\dbch\af31505\loch\f2 correctly.
+\par \hich\af2\dbch\af31505\loch\f2         FQDN should be used; hostname can be used if it can be resolved correctly.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -423,12 +424,12 @@ LICustom] [-PDF] [-Chart] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \l
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file w\hich\af2\dbch\af31505\loch\f2 ith an .html extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                F\hich\af2\dbch\af31505\loch\f2 alse
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -436,23 +437,23 @@ LICustom] [-PDF] [-Chart] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \l
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?        \hich\af2\dbch\af31505\loch\f2             false
+\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date time sta\hich\af2\dbch\af31505\loch\f2 mp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to\hich\af2\dbch\af31505\loch\f2  the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, 2021 at 6PM is 2021-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Output filename will be ReportName_2021-06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2022 at 6PM is 2022-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2022-06-01_1800.docx (or .pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Acc\hich\af2\dbch\af31505\loch\f2 ept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
@@ -462,94 +463,82 @@ LICustom] [-PDF] [-Chart] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \l
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characte\hich\af2\dbch\af31505\loch\f2 rs?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Full [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Runs a full inventory for the Hosts, clusters, resource pools, networking and
-\par \hich\af2\dbch\af31505\loch\f2         virtual machines.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid7552153 
-\par }\pard \ltrpar\s19\ql \fi135\li720\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0\pararsid3086507 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 This\hich\af2\dbch\af31505\loch\f2 
- parameter is disabled by default - only a summary run}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 
- when this}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  
-\par \hich\af2\dbch\af31505\loch\f2 p}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 arameter is not specified.
-\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7552153 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 
+\par \hich\af2\dbch\af31505\loch\f2         virtual machines.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default - only a summary runs when this
+\par \hich\af2\dbch\af31505\loch\f2         parameter is no\hich\af2\dbch\af31505\loch\f2 t specified.
+\par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Export [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Export [<SwitchParame\hich\af2\dbch\af31505\loch\f2 ter>]
 \par \hich\af2\dbch\af31505\loch\f2         Runs this script gathering all required data from PowerCLI as normal, then
-\par \hich\af2\dbch\af31505\loch\f2         exp\hich\af2\dbch\af31505\loch\f2 orting data to XML files in the .\\Export directory}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 .}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid7552153 
-\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid15276959 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15276959\charrsid15276959 \tab 
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15276959 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15276959\charrsid15276959 \hich\af2\dbch\af31505\loch\f2 
-Export honors the path specified with the Folder parameter when the script }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15276959 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15276959\charrsid15276959 \hich\af2\dbch\af31505\loch\f2 creates the Export directory.}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid15276959 
+\par \hich\af2\dbch\af31505\loch\f2         exporting data to XML files in the .\\Export directory.
 \par 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2         Once the export }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2 c}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 , }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2 you }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 
-\hich\af2\dbch\af31505\loch\f2 can cop}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2 y}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2 it }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 offline to run later with}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 the }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 
-\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7552153 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 -Import parameter}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 .}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid7552153 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2         This parameter overrides all other output formats
+\par \hich\af2\dbch\af31505\loch\f2         Export honors the path specified with the Folder parameter when the script
+\par \hich\af2\dbch\af31505\loch\f2         creates the Export directory.
 \par 
-\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid3086507 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \tab 
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 
-The following parameters are set to False or Null.
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 HTML
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 MSWord
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 PDF
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 Text
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 AddDateTime
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 Chart
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 CompanyAddress
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 CompanyEmail
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 CompanyFax
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 CompanyName
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 CompanyPhone
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 CoverPage
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 From
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 Import
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 Issues
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 ReportFooter
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 SmtpServer
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 SmtpPort
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 To
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 UseSSL
-\par \tab }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3086507\charrsid3086507 \hich\af2\dbch\af31505\loch\f2 UserName}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid3086507 
+\par \hich\af2\dbch\af31505\loch\f2         Once the export completes, you can copy it offline to run later with the
+\par \hich\af2\dbch\af31505\loch\f2         -Import parameter.
 \par 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7552153 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         This parameter overrides all other output formats.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The following parameters are set to Fals\hich\af2\dbch\af31505\loch\f2 e or Null.
+\par \hich\af2\dbch\af31505\loch\f2         HTML
+\par \hich\af2\dbch\af31505\loch\f2         MSWord
+\par \hich\af2\dbch\af31505\loch\f2         PDF
+\par \hich\af2\dbch\af31505\loch\f2         Text
+\par \hich\af2\dbch\af31505\loch\f2         AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2         Chart
+\par \hich\af2\dbch\af31505\loch\f2         CompanyAddress
+\par \hich\af2\dbch\af31505\loch\f2         CompanyEmail
+\par \hich\af2\dbch\af31505\loch\f2         CompanyFax
+\par \hich\af2\dbch\af31505\loch\f2         CompanyName
+\par \hich\af2\dbch\af31505\loch\f2         CompanyPhone
+\par \hich\af2\dbch\af31505\loch\f2         CoverPage
+\par \hich\af2\dbch\af31505\loch\f2         From
+\par \hich\af2\dbch\af31505\loch\f2         Import
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Issues
+\par \hich\af2\dbch\af31505\loch\f2         ReportFooter
+\par \hich\af2\dbch\af31505\loch\f2         SmtpServer
+\par \hich\af2\dbch\af31505\loch\f2         SmtpPort
+\par \hich\af2\dbch\af31505\loch\f2         To
+\par \hich\af2\dbch\af31505\loch\f2         UseSSL
+\par \hich\af2\dbch\af31505\loch\f2         UserName
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Import [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Runs this script gathering all required data from a previously run Export
-\par \hich\af2\dbch\af31505\loch\f2         Export directory must be present in the same \hich\af2\dbch\af31505\loch\f2 directory as the script itself
+\par \hich\af2\dbch\af31505\loch\f2         Expo\hich\af2\dbch\af31505\loch\f2 rt directory must be present in the same directory as the script itself
 \par \hich\af2\dbch\af31505\loch\f2         Does not require PowerCLI or a VIServerName to run in Import mode
+\par \hich\af2\dbch\af31505\loch\f2         This parameter overrides all other output formats
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeli\hich\af2\dbch\af31505\loch\f2 ne input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Outputs all errors to a text file at the end of the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is \hich\af2\dbch\af31505\loch\f2 disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled\hich\af2\dbch\af31505\loch\f2  by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -557,14 +546,14 @@ The following parameters are set to False or Null.
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchP\hich\af2\dbch\af31505\loch\f2 arameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcar\hich\af2\dbch\af31505\loch\f2 d characters?  false
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
@@ -576,7 +565,7 @@ The following parameters are set to False or Null.
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?   \hich\af2\dbch\af31505\loch\f2     false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ReportFooter [<SwitchParameter>]
@@ -586,39 +575,39 @@ The following parameters are set to False or Null.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Report Footer
 \par \hich\af2\dbch\af31505\loch\f2                 Report information:
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2                    Created with: <Script Name> - Release Date: <Script Release }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2                         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 Date>
+\par \hich\af2\dbch\af31505\loch\f2                         Created with: <Script Name> - Release Date: <Script Release
+\par \hich\af2\dbch\af31505\loch\f2                         Date>
 \par \hich\af2\dbch\af31505\loch\f2                         Script version: <Script Version>
-\par \hich\af2\dbch\af31505\loch\f2                         Started on <Date Time in Local Format>
-\par \hich\af2\dbch\af31505\loch\f2                         El\hich\af2\dbch\af31505\loch\f2 apsed time: nn days, nn hours, nn minutes, nn.nn seconds
+\par \hich\af2\dbch\af31505\loch\f2                         Started on <Date Time in \hich\af2\dbch\af31505\loch\f2 Local Format>
+\par \hich\af2\dbch\af31505\loch\f2                         Elapsed time: nn days, nn hours, nn minutes, nn.nn seconds
 \par \hich\af2\dbch\af31505\loch\f2                         Ran from domain <Domain Name> by user <Username>
 \par \hich\af2\dbch\af31505\loch\f2                         Ran from the folder <Folder Name>
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Script Name and Script Release date are script-specific var\hich\af2\dbch\af31505\loch\f2 iables.
+\par \hich\af2\dbch\af31505\loch\f2         Script Name and Scr\hich\af2\dbch\af31505\loch\f2 ipt Release date are script-specific variables.
 \par \hich\af2\dbch\af31505\loch\f2         Script version is a script variable.
 \par \hich\af2\dbch\af31505\loch\f2         Start Date Time in Local Format is a script variable.
 \par \hich\af2\dbch\af31505\loch\f2         Elapsed time is a calculated value.
 \par \hich\af2\dbch\af31505\loch\f2         Domain Name is $env:USERDNSDOMAIN.
-\par \hich\af2\dbch\af31505\loch\f2         Username is $env:USERNAME.
+\par \hich\af2\dbch\af31505\loch\f2         Userna\hich\af2\dbch\af31505\loch\f2 me is $env:USERNAME.
 \par \hich\af2\dbch\af31505\loch\f2         Folder Name is a script variable.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildc\hich\af2\dbch\af31505\loch\f2 ard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Issues [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is still beta and is disabled by default
 \par \hich\af2\dbch\af31505\loch\f2         Gathers basic summary data as well as specific issues data with the idea to be
 \par \hich\af2\dbch\af31505\loch\f2         run on a set schedule
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    This parameter does not currently support Import\\Export
+\par \hich\af2\dbch\af31505\loch\f2         This parameter does not currently support Import\\Export
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?              \hich\af2\dbch\af31505\loch\f2       named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PCLICustom [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Prompts user to locate the PowerCLI Scripts directory in a non-default
@@ -626,10 +615,10 @@ The following parameters are set to False or Null.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Po\hich\af2\dbch\af31505\loch\f2 sition?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
@@ -637,33 +626,33 @@ The following parameters are set to False or Null.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         D\hich\af2\dbch\af31505\loch\f2 efault value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter require\hich\af2\dbch\af31505\loch\f2 s Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?  \hich\af2\dbch\af31505\loch\f2      false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Chart [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is still beta and is disabled by default
-\par \hich\af2\dbch\af31505\loch\f2         Gathers data from VMware stats to build p\hich\af2\dbch\af31505\loch\f2 erformance graphs for hosts and VMs
+\par \hich\af2\dbch\af31505\loch\f2         This parameter i\hich\af2\dbch\af31505\loch\f2 s still beta and is disabled by default
+\par \hich\af2\dbch\af31505\loch\f2         Gathers data from VMware stats to build performance graphs for hosts and VMs
 \par \hich\af2\dbch\af31505\loch\f2         DOTNET chart controls are required
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is supported for MSWord and PDF only
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?         \hich\af2\dbch\af31505\loch\f2            false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value        \hich\af2\dbch\af31505\loch\f2         False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -671,24 +660,24 @@ The following parameters are set to False or Null.
 \par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address
 \par \hich\af2\dbch\af31505\loch\f2         field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cov\hich\af2\dbch\af31505\loch\f2 er Pages have an Address field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Expos\hich\af2\dbch\af31505\loch\f2 ure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospe\hich\af2\dbch\af31505\loch\f2 ct (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word \hich\af2\dbch\af31505\loch\f2 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alia\hich\af2\dbch\af31505\loch\f2 s of CA.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Acce\hich\af2\dbch\af31505\loch\f2 pt pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
@@ -696,23 +685,23 @@ The following parameters are set to False or Null.
 \par \hich\af2\dbch\af31505\loch\f2         field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
-\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid \hich\af2\dbch\af31505\loch\f2 with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wil\hich\af2\dbch\af31505\loch\f2 dcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax fi\hich\af2\dbch\af31505\loch\f2 eld.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word \hich\af2\dbch\af31505\loch\f2 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
@@ -724,26 +713,26 @@ The following parameters are set to False or Null.
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is conta\hich\af2\dbch\af31505\loch\f2 ined in
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for th\hich\af2\dbch\af31505\loch\f2 e Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is
 \par \hich\af2\dbch\af31505\loch\f2         populated on the computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       If either registry key does not exist and this parameter is not specified, the
+\par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is not specified\hich\af2\dbch\af31505\loch\f2 , the
 \par \hich\af2\dbch\af31505\loch\f2         report will not contain a Company Name on the cover page.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Default v\hich\af2\dbch\af31505\loch\f2 alue
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cov\hich\af2\dbch\af31505\loch\f2 er Page has the Phone field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone fi\hich\af2\dbch\af31505\loch\f2 eld:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
@@ -751,9 +740,9 @@ The following parameters are set to False or Null.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline\hich\af2\dbch\af31505\loch\f2  input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
@@ -763,47 +752,47 @@ The following parameters are set to False or Null.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't \hich\af2\dbch\af31505\loch\f2 work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
-\par \hich\af2\dbch\af31505\loch\f2                 \hich\af2\dbch\af31505\loch\f2 works in 2010 but Subtitle/Subject & Author fields need to be moved
-\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
+\par \hich\af2\dbch\af31505\loch\f2                 afte\hich\af2\dbch\af31505\loch\f2 r title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if yo\hich\af2\dbch\af31505\loch\f2 u like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (W\hich\af2\dbch\af31505\loch\f2 ord 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point\hich\af2\dbch\af31505\loch\f2 )
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually chan\hich\af2\dbch\af31505\loch\f2 ged to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; bo\hich\af2\dbch\af31505\loch\f2 x needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, wo\hich\af2\dbch\af31505\loch\f2 rks in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless change\hich\af2\dbch\af31505\loch\f2 d to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Tr\hich\af2\dbch\af31505\loch\f2 anscend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSW\hich\af2\dbch\af31505\loch\f2 ORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -811,16 +800,16 @@ The following parameters are set to False or Null.
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
+\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of \hich\af2\dbch\af31505\loch\f2 UN.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?    \hich\af2\dbch\af31505\loch\f2    false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       f\hich\af2\dbch\af31505\loch\f2 alse
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
@@ -828,8 +817,8 @@ The following parameters are set to False or Null.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default valu\hich\af2\dbch\af31505\loch\f2 e
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
@@ -838,12 +827,12 @@ The following parameters are set to False or Null.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                25
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServe\hich\af2\dbch\af31505\loch\f2 r.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         Default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -852,12 +841,12 @@ The following parameters are set to False or Null.
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -From \hich\af2\dbch\af31505\loch\f2 <String>
+\par \hich\af2\dbch\af31505\loch\f2     -From <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?            \hich\af2\dbch\af31505\loch\f2         named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -866,7 +855,7 @@ The following parameters are set to False or Null.
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                \hich\af2\dbch\af31505\loch\f2     false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -874,55 +863,54 @@ The following parameters are set to False or Null.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000302fc00}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216
-}}}\sectd \ltrsect\linex0\endnhere\sectlinegrid360\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 https:/g\hich\af2\dbch\af31505\loch\f2 
+o.microsoft.com/fwlink/?LinkID=113216}}}\sectd \ltrsect\linex0\endnhere\sectlinegrid360\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this \hich\af2\dbch\af31505\loch\f2 script.
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.
 \par \hich\af2\dbch\af31505\loch\f2     This script creates a Word, PDF, Formatted Text or HTML document.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         NAME: VMware_Inventory.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.92
+\par \hich\af2\dbch\af31505\loch\f2         NAME: VMware_In\hich\af2\dbch\af31505\loch\f2 ventory.ps1
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.93
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Jacob Rutski and Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: September }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10501565 \hich\af2\dbch\af31505\loch\f2 21}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 
-\hich\af2\dbch\af31505\loch\f2 , 2021
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: February 23, 2022
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses all default values and prompts for the vCenter Server.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName=
+\par \hich\af2\dbch\af31505\loch\f2     The script uses all de\hich\af2\dbch\af31505\loch\f2 fault values and prompts for the vCenter Server.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName=
 \par \hich\af2\dbch\af31505\loch\f2     "Jacob Rutski" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Jacob Rutski"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Jacob Rutski for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover \hich\af2\dbch\af31505\loch\f2 Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 2 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -VIServerName testvc.lab.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses all default values and use testvc.lab.co\hich\af2\dbch\af31505\loch\f2 m as the vCenter Server.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName=
+\par \hich\af2\dbch\af31505\loch\f2     The script uses all default values and use testvc.lab.com as the vCenter Server.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Of\hich\af2\dbch\af31505\loch\f2 fice\\Common\\UserInfo\\CompanyName=
 \par \hich\af2\dbch\af31505\loch\f2     "Jacob Rutski" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Jacob Rutski"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -936,12 +924,12 @@ The following parameters are set to False or Null.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inv\hich\af2\dbch\af31505\loch\f2 entory.ps1 -PDF -VIServerName testvc.lab.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -PDF -VIServerName testvc.lab.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses all default values and save the document as a PDF file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName=
 \par \hich\af2\dbch\af31505\loch\f2     "Jacob Rutski" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micr\hich\af2\dbch\af31505\loch\f2 osoft\\Office\\Common\\UserInfo\\Company="Jacob Rutski"
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Jacob Rutski"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Jacob Rutski for the Company Name.
@@ -951,13 +939,13 @@ The following parameters are set to False or Null.
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------\hich\af2\dbch\af31505\loch\f2 ------------- EXAMPLE 4 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -TEXT -VIServerName testvc.lab.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This parameter outputs a basic txt file.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses all default values and save the document a\hich\af2\dbch\af31505\loch\f2 s a formatted text file.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses all default values and save the document as a formatted tex\hich\af2\dbch\af31505\loch\f2 t file.
 \par 
 \par 
 \par 
@@ -968,7 +956,7 @@ The following parameters are set to False or Null.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This parameter will output an HTML report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses all default\hich\af2\dbch\af31505\loch\f2  values and save the document as an HTML file.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses all default values and save the document as an HTML file.
 \par 
 \par 
 \par 
@@ -977,12 +965,12 @@ The following parameters are set to False or Null.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -Full -VIServerName testvc.lab.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a full inventory of the VMware environment. *\hich\af2\dbch\af31505\loch\f2 Note: a full report will take
+\par \hich\af2\dbch\af31505\loch\f2     Creates a full invento\hich\af2\dbch\af31505\loch\f2 ry of the VMware environment. *Note: a full report will take
 \par \hich\af2\dbch\af31505\loch\f2     a considerable amount of time to generate.
 \par \hich\af2\dbch\af31505\loch\f2     The script uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName=
 \par \hich\af2\dbch\af31505\loch\f2     "Jacob Rutski" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Jacob Rutski"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_\hich\af2\dbch\af31505\loch\f2 CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Jacob Rutski"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Jacob Rutski for the Company Name.
@@ -992,16 +980,16 @@ The following parameters are set to False or Null.
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -PDF -Full -VIServerName testvc.lab.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a full inventory of the VMware environment. *Note: a full report will take
-\par \hich\af2\dbch\af31505\loch\f2     a considerable amount of t\hich\af2\dbch\af31505\loch\f2 ime to generate.
+\par \hich\af2\dbch\af31505\loch\f2     a considerab\hich\af2\dbch\af31505\loch\f2 le amount of time to generate.
 \par \hich\af2\dbch\af31505\loch\f2     The script uses all Default values and save the document as a PDF file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName=
 \par \hich\af2\dbch\af31505\loch\f2     "Jacob Rutski" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Jacob Rutski"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Co\hich\af2\dbch\af31505\loch\f2 mmon\\UserInfo\\Company="Jacob Rutski"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Jacob Rutski for the Company Name.
@@ -1013,12 +1001,13 @@ The following parameters are set to False or Null.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\VMware_Inventory.ps1 -CompanyName "SeriousTek" -CoverPage }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 "Mod" -UserName "Jacob Rutski" -VIServerName testvc.lab.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\VMware_Inventory.ps1 -CompanyName "SeriousTek" -CoverPage}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16072335\charrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     "Mod" -UserName "Jacob Rutski" -VIServerName testvc.lab.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses:
-\par \hich\af2\dbch\af31505\loch\f2         Jacob \hich\af2\dbch\af31505\loch\f2 Rutski Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Jacob Rutski Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Mod for the Cove\hich\af2\dbch\af31505\loch\f2 r Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Jacob Rutski for the User Name.
 \par 
 \par 
@@ -1026,7 +1015,7 @@ The following parameters are set to False or Null.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\VMware_Inventory.ps1 -Export -VIServ\hich\af2\dbch\af31505\loch\f2 erName testvc.lab.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\VMware_Inventory.ps1 -Export -VIServerName testvc.lab.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses all default values and use testvc.lab.com as the vCenter Server.
 \par \hich\af2\dbch\af31505\loch\f2     Script will output all data to XML files in the .\\Export directory created
@@ -1034,13 +1023,13 @@ The following parameters are set to False or Null.
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    -------------------------- EXAMPLE 10 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\VMware_Inventory.ps1 -CN "SeriousTek" -CP "Mod" -UN "Jacob }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 Rutski" -VIServerName testvc.lab.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\VMware_Inventory.ps1 -CN "SeriousTek" -CP "Mod" -UN "Jacob}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2     Rutski" -VIServerName testvc.lab.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses:
-\par \hich\af2\dbch\af31505\loch\f2         Jacob Rutski Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2         Jacob Rutski Consulting for \hich\af2\dbch\af31505\loch\f2 the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Jacob Rutski for the User Name (alias UN).
 \par 
@@ -1049,76 +1038,93 @@ The following parameters are set to False or Null.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScri\hich\af2\dbch\af31505\loch\f2 pt >.\\VMware_Inventory.ps1 -AddDateTime -VIServerName testvc.lab.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -AddDateTime -VIServerName}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2  
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2     testvc.lab.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName=
 \par \hich\af2\dbch\af31505\loch\f2     "Jacob Rutski" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\Company="Jacob Rutski"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Soft\hich\af2\dbch\af31505\loch\f2 ware\\Microsoft\\Office\\Common\\UserInfo\\Company="Jacob Rutski"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Jacob Rutski for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     Time\hich\af2\dbch\af31505\loch\f2  stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be vCenterServer_2021-06-01_1800.docx
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of th\hich\af2\dbch\af31505\loch\f2 e file name.
+\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2022 at 6PM is 2022-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be vCenterServer_2022-06-01_1800.docx
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------------------\hich\af2\dbch\af31505\loch\f2 -------- EXAMPLE 12 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -PDF -AddDateTime -VIServerName}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7552153\charrsid7552153 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\VMware_Inventory.ps1 -PDF -AddDateTime -VIServerName
 \par \hich\af2\dbch\af31505\loch\f2     testvc.lab.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micro\hich\af2\dbch\af31505\loch\f2 soft\\Office\\Common\\UserInfo\\CompanyName=
+\par \hich\af2\dbch\af31505\loch\f2     The script uses all Default values and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2 saves}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 
+\hich\af2\dbch\af31505\loch\f2  the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName=
 \par \hich\af2\dbch\af31505\loch\f2     "Jacob Rutski" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Jacob Rutski"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Jacob Rutski for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page \hich\af2\dbch\af31505\loch\f2 format.
+\par \hich\af2\dbch\af31505\loch\f2     Jacob Rutski for the Company Na\hich\af2\dbch\af31505\loch\f2 me.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be vCenterServerSiteName_2021-06-\hich\af2\dbch\af31505\loch\f2 01_1800.pdf
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2022 at 6PM is 2022-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename wi\hich\af2\dbch\af31505\loch\f2 ll be vCenterServerSiteName_2022-06-01_1800.pdf
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -Folder \\\\FileServer\\ShareName}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7552153\charrsid7552153 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -Folder \\\\FileServer\\ShareName
 \par \hich\af2\dbch\af31505\loch\f2     -VIServerName testvc.lab.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses all default values.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses all d\hich\af2\dbch\af31505\loch\f2 efault values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName=
 \par \hich\af2\dbch\af31505\loch\f2     "Jacob Rutski" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Jacob Rutski"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administra\hich\af2\dbch\af31505\loch\f2 tor
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Jacob Rutski for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2 The o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 utput file save
-}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2  in the path \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -SmtpServer mail.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7552153\charrsid7552153 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -Dev -ScriptInfo -Log
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates the default report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named VMwareDocScriptErrors_yyyyMMddTHHmmssffff.txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates \hich\af2\dbch\af31505\loch\f2 a text file named VMwareDocScriptInfo_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
+\par \hich\af2\dbch\af31505\loch\f2     VMwareDocScriptTranscript_yyyyMMddTHHmmssffff.txt.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     --------\hich\af2\dbch\af31505\loch\f2 ------------------ EXAMPLE 15 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -SmtpServer mail.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16072335\charrsid16072335 
 \par \hich\af2\dbch\af31505\loch\f2     VMWAdmin@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sending from VMWAdmin@domain.tld
@@ -1132,37 +1138,37 @@ The following parameters are set to False or Null.
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 VMware_Inventory.ps1 -SmtpServer mailrelay.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -SmtpServer mailrelay.domain.tld -From}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16072335\charrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To I\hich\af2\dbch\af31505\loch\f2 TGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mailrelay.domain.tld, sending from
-\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld and send\hich\af2\dbch\af31505\loch\f2 ing to ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     anonymous@domain.tld and sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated email using an email relay server requires the From
+\par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated email using an email relay serve\hich\af2\dbch\af31505\loch\f2 r requires the From
 \par \hich\af2\dbch\af31505\loch\f2     email account to use the name Anonymous.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY\hich\af2\dbch\af31505\loch\f2 ***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7552153 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000bf}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\endnhere\sectlinegrid360\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2  HYPER\hich\af2\dbch\af31505\loch\f2 LINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003207311}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 
-https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\endnhere\sectlinegrid360\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using \hich\af2\dbch\af31505\loch\f2 a Gmail or g-suite account, you may have to turn ON the
-\par \hich\af2\dbch\af31505\loch\f2     "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\endnhere\sectlinegrid360\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 
+https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\endnhere\sectlinegrid360\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the
+\par \hich\af2\dbch\af31505\loch\f2     "Less secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     ***GMAIL\hich\af2\dbch\af31505\loch\f2 /G SUITE SMTP RELAY***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
@@ -1170,29 +1176,30 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\endnhe
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -SmtpServer}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7552153\charrsid7552153 
-\par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -SmtpServer}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16072335\charrsid16072335 
+\par \hich\af2\dbch\af31505\loch\f2     l\hich\af2\dbch\af31505\loch\f2 abaddomain-com.mail.protection.outlook.com -UseSSL -From
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2 
- HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 
+{\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000000}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7552153\charrsid7552153 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-\hich\af2\dbch\af31505\loch\f2 
-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\endnhere\sectlinegrid360\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid16072335\charrsid16072335 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-\hich\af2\dbch\af31505\loch\f2 
+device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\endnhere\sectlinegrid360\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335\charrsid16072335 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protection.outlook.com,
-\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomai\hich\af2\dbch\af31505\loch\f2 n.com and sending to
+\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com and sending to
 \par \hich\af2\dbch\af31505\loch\f2     ITGroupDL@labaddomain.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and SSL.
@@ -1200,14 +1207,14 @@ device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\endn
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ---------------\hich\af2\dbch\af31505\loch\f2 ----------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -SmtpServer smtp.office365.com -\hich\af2\dbch\af31505\loch\f2 SmtpPort}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153\charrsid7552153 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -SmtpServer smtp.office365.com -SmtpPort}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16072335\charrsid16072335 
 \par \hich\af2\dbch\af31505\loch\f2     587 -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 587 using SSL, sending
-\par \hich\af2\dbch\af31505\loch\f2     from w\hich\af2\dbch\af31505\loch\f2 ebster@carlwebster.com and sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.off\hich\af2\dbch\af31505\loch\f2 ice365.com on port 587 using SSL, sending
+\par \hich\af2\dbch\af31505\loch\f2     from webster@carlwebster.com and sending to ITGroup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script
 \par \hich\af2\dbch\af31505\loch\f2     prompts the user to enter valid credentials.
@@ -1215,22 +1222,22 @@ device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\endn
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --\hich\af2\dbch\af31505\loch\f2 ------------------------ EXAMPLE 19 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7552153 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid7552153\charrsid7552153 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\VMware_Inventory.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16072335 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid16072335\charrsid16072335 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to \hich\af2\dbch\af31505\loch\f2 turn ON the
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the
 \par \hich\af2\dbch\af31505\loch\f2     "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.gmail.com on port 587 using SSL, sending
+\par \hich\af2\dbch\af31505\loch\f2     The script\hich\af2\dbch\af31505\loch\f2  uses the email server smtp.gmail.com on port 587 using SSL, sending
 \par \hich\af2\dbch\af31505\loch\f2     from webster@gmail.com and sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current use\hich\af2\dbch\af31505\loch\f2 r's credentials are not valid to send an email, the script
-\par \hich\af2\dbch\af31505\loch\f2     prompts the user to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script
+\par \hich\af2\dbch\af31505\loch\f2     prompts the user to enter valid cr\hich\af2\dbch\af31505\loch\f2 edentials.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
@@ -1374,10 +1381,10 @@ fffffffffffffffffdffffff04000000feffffff05000000fefffffffeffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e5000000000000000000000000b0c6
-1689d4aed70103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff020000000000000000000000000000000000000000000000b0c61689d4aed701
-b0c61689d4aed701000000000000000000000000c700460057005000d500ca00d00044004700d40057003500d7004e00cd0053003100c2003200d900d300d0003d003d000000000000000000000000000000000032000101ffffffffffffffff030000000000000000000000000000000000000000000000b0c61689d4ae
-d701b0c61689d4aed7010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffff010000000c6ad98892f1d411a65f0040963251e500000000000000000000000090d8
+ae45c328d80103000000c0020000000000004d0073006f004400610074006100530074006f0072006500000000000000000000000000000000000000000000000000000000000000000000000000000000001a000101ffffffffffffffff02000000000000000000000000000000000000000000000090d8ae45c328d801
+90d8ae45c328d801000000000000000000000000c700460057005000d500ca00d00044004700d40057003500d7004e00cd0053003100c2003200d900d300d0003d003d000000000000000000000000000000000032000101ffffffffffffffff03000000000000000000000000000000000000000000000090d8ae45c328
+d80190d8ae45c328d8010000000000000000000000004900740065006d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000201ffffffff04000000ffffffff000000000000000000000000000000000000000000000000
 00000000000000000000000000000000320100000000000001000000020000000300000004000000feffffff060000000700000008000000090000000a000000feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/VMware_Script_ChangeLog.txt
+++ b/VMware_Script_ChangeLog.txt
@@ -9,6 +9,23 @@
 #@carlwebster on Twitter
 #http://www.CarlWebster.com
 
+#Version 1.93 23-Feb-2022
+#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
+#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
+#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
+#		For example: 20221225T0840107271.
+#	Fixed the German Table of Contents (Thanks to Rene Bigler)
+#		From 
+#			'de-'	{ 'Automatische Tabelle 2'; Break }
+#		To
+#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
+#	In Function AbortScript, add test for the winword process and terminate it if it is running
+#		Added stopping the transcript log if the log was enabled and started
+#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
+#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
+#	Updated the help text
+#	Updated the ReadMe file
+
 #Version 1.92 21-Sep-2021
 #	Added a message at the end of the script stating id the disconnection from the vCenter server was successful or not
 #	Added array error checking for non-empty arrays before attempting to create the Word table for most Word tables


### PR DESCRIPTION
#Version 1.93 23-Feb-2022
#	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
#		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 
#		the letter T as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). 
#		For example: 20221225T0840107271.
#	Fixed the German Table of Contents (Thanks to Rene Bigler)
#		From 
#			'de-'	{ 'Automatische Tabelle 2'; Break }
#		To
#			'de-'	{ 'Automatisches Verzeichnis 2'; Break }
#	In Function AbortScript, add test for the winword process and terminate it if it is running
#		Added stopping the transcript log if the log was enabled and started
#	In Functions AbortScript and SaveandCloseDocumentandShutdownWord, add code from Guy Leech to test for the "Id" property before using it
#	Replaced most script Exit calls with AbortScript to stop the transcript log if the log was enabled and started
#	Updated the help text
#	Updated the ReadMe file